### PR TITLE
be more careful when parsing the test-source.js script

### DIFF
--- a/karma-qooxdoo.js
+++ b/karma-qooxdoo.js
@@ -63,8 +63,12 @@ var initQooxdoo = function(logger, config, customFilehandlers) {
     var qx = {};
 
     // loads urisBefore
-    var matches = source.match(/\s*urisBefore : \[(.*)\],\n/);
-    eval("var urisBefore = ["+matches[1]+"]");
+    var matches = source.match(/\s*urisBefore : (\[.*\]),\n/);
+    if (!matches){
+      log.error("Failed to find 'urisBefore' property qx.$$loader in "+testSourceFile);
+      process.exit();
+    }
+    var urisBefore = eval(matches[1].toString());
     urisBefore.forEach(function(uri) {
       if (includeFiles) {
         files.unshift(createPattern(path.join(basePath, 'source', uri), false));
@@ -76,12 +80,20 @@ var initQooxdoo = function(logger, config, customFilehandlers) {
     });
 
     // read libinfo
-    matches = source.match("var libinfo = {(.*)};\n");
-    eval("qx.$$libraries = {" + matches[1] + "};");
+    matches = source.match(/var libinfo = ({.*});\n/);
+    if (!matches){
+      log.error("Failed to find 'var libinfo' in "+testSourceFile);
+      process.exit();
+    }
+    qx.$$libraries = eval(matches[1].toString());
 
     // read loader settings
-    matches = source.match(/qx\.\$\$loader = {\n((.|\n)+)(?=^};$\n\n)/m);
-    eval("var loader = qx.$$loader = { " + matches[1] + " };");
+    matches = source.match(/\nqx\.\$\$loader = ({\n[.\n]*?\n});\n\n/);
+    if (!matches){
+      log.error("Failed to find 'qx.$$loader in "+testSourceFile);
+      process.exit();
+    }
+    var loader = qx.$$loader = eval(matches[1].toString());
     qx.$$loader.addNoCacheParam = false;
 
     // load project files


### PR DESCRIPTION
Not sure this fixes any bug ... just what I found while trying to find reasons why https://github.com/qooxdoo/qooxdoo/pull/9012 is not raising coverage ... 

The patch extracts data from test-source.js such that it can be fed directly to `eval` and it checks whether the regexp actually matched anything before proceeding.
